### PR TITLE
Bootstrap VerdLedger platform skeleton

### DIFF
--- a/.github/workflows/iac-advisor.yml
+++ b/.github/workflows/iac-advisor.yml
@@ -1,0 +1,16 @@
+name: IaC Advisor
+on: [pull_request]
+jobs:
+  advisor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint Terraform
+        run: |
+          echo "Linting Terraform..."
+          # placeholder for terraform lint
+      - name: Suggest greener alternatives
+        run: |
+          echo "Compute savings..."
+          echo "kWh saved: 0"
+          echo "CO2 saved: 0"

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# VerdLedger
+
+VerdLedger is a "Ledger-as-a-Service" platform for tracking carbon savings from infrastructure changes.
+
+This repository currently includes the database schema defined via Supabase. More features will be added over time including REST endpoints, a CLI, GitHub actions and a dashboard.
+

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "verd-cli",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "bin": {
+    "verd": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "commander": "^11.1.0",
+    "@supabase/supabase-js": "^2.39.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { createClient } from '@supabase/supabase-js';
+import fs from 'fs';
+
+const program = new Command();
+program.name('verd').description('VerdLedger CLI').version('0.1.0');
+
+program
+  .command('push <file>')
+  .description('Push a local plan result to the ledger')
+  .action(async (file) => {
+    const content = fs.readFileSync(file, 'utf8');
+    const data = JSON.parse(content);
+    const supabase = createClient(process.env.SUPABASE_URL || '', process.env.SUPABASE_SERVICE_KEY || '');
+    await supabase.from('savings_event').insert(data);
+    console.log('Pushed events to ledger');
+  });
+
+program.parse(process.argv);

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"]
+}

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "verd-dashboard",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  }
+}

--- a/dashboard/pages/index.tsx
+++ b/dashboard/pages/index.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>VerdLedger Dashboard</h1>
+      <p>Coming soon...</p>
+    </div>
+  );
+}

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "verdledger-server",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "@supabase/supabase-js": "^2.39.5"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,0 +1,36 @@
+import express from 'express';
+import { createClient } from '@supabase/supabase-js';
+
+const PORT = process.env.PORT || 3000;
+const SUPABASE_URL = process.env.SUPABASE_URL || '';
+const SUPABASE_KEY = process.env.SUPABASE_SERVICE_KEY || '';
+
+const supabase = createClient(SUPABASE_URL, SUPABASE_KEY);
+
+const app = express();
+app.use(express.json());
+
+app.get('/v1/skus', async (_req, res) => {
+  const { data, error } = await supabase.from('sku_catalogue').select('*');
+  if (error) return res.status(500).json({ error: error.message });
+  res.json(data);
+});
+
+app.get('/v1/events', async (_req, res) => {
+  const { data, error } = await supabase.from('savings_event').select('*');
+  if (error) return res.status(500).json({ error: error.message });
+  res.json(data);
+});
+
+app.get('/v1/summary', async (_req, res) => {
+  const { data, error } = await supabase
+    .from('savings_event')
+    .select('org_id, sum(kwh) as kwh, sum(kg) as kg, sum(usd) as usd')
+    .group('org_id');
+  if (error) return res.status(500).json({ error: error.message });
+  res.json(data);
+});
+
+app.listen(PORT, () => {
+  console.log(`VerdLedger API listening on port ${PORT}`);
+});

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add project overview in README
- bootstrap Express server with REST endpoints
- add VerdLedger CLI skeleton
- set up placeholder Next.js dashboard
- introduce IaC Advisor GitHub Action

## Testing
- `git status --short`
- `git commit -m "Bootstrap VerdLedger components" && git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685efec0521c83229d004d9b1f28dfee