### PR TITLE
Add VerdLedger IaC advisor action

### DIFF
--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -1,0 +1,21 @@
+name: IaC Advisor Action CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 9
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: pnpm install
+      - run: pnpm -F iac-advisor-action test -- --run
+      - run: pnpm -F iac-advisor-action package

--- a/iac-advisor-action/README.md
+++ b/iac-advisor-action/README.md
@@ -1,0 +1,10 @@
+# VerdLedger IaC Advisor Action
+
+Comment estimated cost and CO\u2082 savings on Terraform pull requests.
+
+```yaml
+- uses: verdledger/iac-advisor-action@v0.1.0
+  with:
+    plan-json: plan.json
+    api-key: ${{ secrets.VERDLEDGER_KEY }}
+```

--- a/iac-advisor-action/action.yml
+++ b/iac-advisor-action/action.yml
@@ -1,0 +1,19 @@
+name: VerdLedger IaC Advisor
+description: Comment cost & CO\u2082 diff on each Terraform plan
+inputs:
+  api-url:
+    description: VerdLedger API base
+    required: true
+    default: https://api.verdledger.dev
+  api-key:
+    description: VerdLedger API key (created in dashboard)
+    required: true
+  plan-json:
+    description: Path to terraform show -json output
+    required: true
+runs:
+  using: node20
+  main: dist/index.js
+branding:
+  icon: cloud
+  color: green

--- a/iac-advisor-action/package.json
+++ b/iac-advisor-action/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@verdledger/iac-advisor-action",
+  "version": "0.1.0",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "esbuild src/index.ts --bundle --platform=node --target=node20 --outfile=dist/index.js",
+    "test": "vitest",
+    "package": "pnpm build"
+  },
+  "dependencies": {
+    "@actions/core": "^1.10.0",
+    "@actions/github": "^6.1.0",
+    "node-fetch": "^3.3.2",
+    "zod": "^3.23.6"
+  },
+  "devDependencies": {
+    "esbuild": "^0.20.0",
+    "vitest": "^1.1.0",
+    "ts-node": "^10.9.1",
+    "@types/node": "^20.10.5"
+  }
+}

--- a/iac-advisor-action/src/index.ts
+++ b/iac-advisor-action/src/index.ts
@@ -1,0 +1,42 @@
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+import { parsePlan } from './plan';
+import { suggest }   from './suggest';
+import fetch from 'node-fetch';
+
+async function run() {
+  try {
+    const api   = core.getInput('api-url');
+    const key   = core.getInput('api-key');
+    const plan  = core.getInput('plan-json');
+
+    const resources = parsePlan(plan);
+    const sugg      = await suggest(resources, api);
+
+    if (!sugg.length) {
+      core.info('No greener alternatives found.');
+      return;
+    }
+
+    const markdown = [
+      `### \u2618\uFE0F VerdLedger suggestions`,
+      '| Current | Greener | \u0394 kg CO\u2082 | \u0394 Cost |',
+      '|---------|---------|---------|-------|',
+      ...sugg.map(s => `| \`${s.sku}\` | \`${s.altSku}\` | **${s.deltaKg.toFixed(2)}** | **$${s.deltaUsd.toFixed(2)}** |`)
+    ].join('\n');
+
+    const token = process.env.GITHUB_TOKEN!;
+    const octo  = github.getOctokit(token);
+    const { owner, repo, number } = github.context.issue;
+
+    await octo.rest.issues.createComment({ owner, repo, issue_number: number, body: markdown });
+
+    // Listen for "verdledger:apply" label on later job
+    core.setOutput('suggestions', JSON.stringify(sugg));
+
+  } catch (err) {
+    core.setFailed((err as Error).message);
+  }
+}
+
+run();

--- a/iac-advisor-action/src/plan.ts
+++ b/iac-advisor-action/src/plan.ts
@@ -1,0 +1,25 @@
+import fs from 'fs';
+
+export type Resource = {
+  provider: string;            // "aws"
+  region:   string;            // "eu-central-1"
+  sku:      string;            // "t3.medium"
+};
+
+export function parsePlan(path: string): Resource[] {
+  const plan = JSON.parse(fs.readFileSync(path,'utf8'));
+  const resources: Resource[] = [];
+
+  plan.resource_changes?.forEach((rc: any) => {
+    if (rc.change.actions.includes('create')) {
+      const provReg = rc.address.split('.')[0];      // aws_instance
+      const [, provider] = provReg.split('_');
+      resources.push({
+        provider,
+        region:  rc.change.after.availability_zone.replace(/[a-z]$/,''),
+        sku:     rc.change.after.instance_type
+      });
+    }
+  });
+  return resources;
+}

--- a/iac-advisor-action/src/suggest.ts
+++ b/iac-advisor-action/src/suggest.ts
@@ -1,0 +1,21 @@
+import fetch from 'node-fetch';
+import type { Resource } from './plan';
+
+export type Suggestion = Resource & { altSku: string; deltaKg: number; deltaUsd: number };
+
+export async function suggest(resources: Resource[], api: string): Promise<Suggestion[]> {
+  const skus = await fetch(`${api}/v1/skus`).then(r => r.json());
+  const table = new Map(skus.map((s: any) => [`${s.cloud}/${s.region}/${s.sku}`, s]));
+
+  return resources.map(r => {
+    const base = table.get(`${r.provider}/${r.region}/${r.sku}`)!;
+    // naive greener choice: same family, "small" instead of "medium"
+    const altSku = r.sku.replace(/medium/,'small');
+    const alt    = table.get(`${r.provider}/${r.region}/${altSku}`) ?? base;
+
+    const deltaKg  = ((base.watts - alt.watts) / 1000) * 0.7; // 0.7 kg/kWh default
+    const deltaUsd = (base.usd_hour - alt.usd_hour) * 730;    // monthly
+
+    return { ...r, altSku, deltaKg, deltaUsd };
+  }).filter(s => s.deltaKg > 0.1);   // only if meaningful
+}

--- a/iac-advisor-action/tests/plan.test.ts
+++ b/iac-advisor-action/tests/plan.test.ts
@@ -1,0 +1,28 @@
+import { parsePlan } from '../src/plan';
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+
+const planPath = __dirname + '/plan.json';
+fs.writeFileSync(planPath, JSON.stringify({
+  resource_changes: [
+    {
+      address: 'aws_instance.demo',
+      change: {
+        actions: ['create'],
+        after: {
+          availability_zone: 'us-west-2b',
+          instance_type: 't3.medium'
+        }
+      }
+    }
+  ]
+}));
+
+describe('parsePlan', () => {
+  it('extracts create resources', () => {
+    const res = parsePlan(planPath);
+    expect(res).toEqual([
+      { provider: 'aws', region: 'us-west-2', sku: 't3.medium' }
+    ]);
+  });
+});

--- a/iac-advisor-action/tests/suggest.test.ts
+++ b/iac-advisor-action/tests/suggest.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+import { suggest } from '../src/suggest';
+import type { Resource } from '../src/plan';
+
+vi.mock('node-fetch', () => ({
+  default: vi.fn(() => Promise.resolve({
+    json: () => Promise.resolve([
+      { cloud: 'aws', region: 'us-west-2', sku: 't3.medium', watts: 100, usd_hour: 0.1 },
+      { cloud: 'aws', region: 'us-west-2', sku: 't3.small',  watts: 70,  usd_hour: 0.07 }
+    ])
+  }))
+}));
+
+it('suggests greener sku', async () => {
+  const resources: Resource[] = [{ provider: 'aws', region: 'us-west-2', sku: 't3.medium' }];
+  const res = await suggest(resources, 'https://api');
+  expect(res.length).toBe(1);
+  expect(res[0].altSku).toBe('t3.small');
+  expect(res[0].deltaKg).toBeGreaterThan(0);
+  expect(res[0].deltaUsd).toBeGreaterThan(0);
+});

--- a/iac-advisor-action/tsconfig.json
+++ b/iac-advisor-action/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}

--- a/iac-advisor-action/vitest.config.ts
+++ b/iac-advisor-action/vitest.config.ts
@@ -1,0 +1,2 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({ test: { environment: 'node' } });

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,4 @@ packages:
   - 'cli'
   - 'server'
   - 'backend'
+  - 'iac-advisor-action'


### PR DESCRIPTION
## Summary
- add new `iac-advisor-action` package
- implement Terraform plan parsing and suggestion logic
- provide GitHub Action entrypoint and workflow CI
- document usage snippet

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/vitest: Forbidden)*
- `pnpm -F iac-advisor-action test -- --run` *(fails: `vitest: not found`)*
- `pnpm -F iac-advisor-action build` *(fails: `esbuild: not found`)*

Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_685f0b6d20c08322ba0769721003b586