### PR TITLE
Add ledger summary function and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ playwright-report/
 # Compiled output (if you have a backend package)                            #
 ###############################################################################
 dist/
+!iac-advisor-action/dist/index.js
 build/
 *.tsbuildinfo
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 
 VerdLedger is a "Ledger-as-a-Service" platform for tracking carbon savings from infrastructure changes.
 
+```bash
+git clone https://github.com/verdledger/verdledger && cd verdledger
+supabase start && pnpm ws run gen:db && pnpm --filter backend dev
+```
+
 This repository currently includes the database schema defined via Supabase. More features will be added over time including REST endpoints, a CLI, GitHub actions and a dashboard.
 
 ### 💚 One-line install

--- a/backend/src/api/routes/summary.ts
+++ b/backend/src/api/routes/summary.ts
@@ -6,14 +6,10 @@ export const summaryRoute =
     const org = Number((req.query as any).org);
     if (!org) return res.badRequest('org required');
 
-    const { data } = await sb
-      .from('savings_event')
-      .select('kg, usd')
-      .eq('org_id', org);
-
-    const total_kg  = data?.reduce((a, b) => a + (b.kg  ?? 0), 0) ?? 0;
-    const total_usd = data?.reduce((a, b) => a + (b.usd ?? 0), 0) ?? 0;
-
-    res.send({ total_kg, total_usd });
+    const { data, error } = await sb
+      .rpc('ledger_summary', { p_org: org })
+      .single();
+    if (error) return res.internalServerError(error);
+    res.send(data as any);
   });
 };

--- a/backend/src/db-types.ts
+++ b/backend/src/db-types.ts
@@ -1,6 +1,146 @@
 // Auto-generated via `pnpm gen:db`
 export type Json = string | number | boolean | null | { [key: string]: Json } | Json[];
 export interface Database {
-  // Placeholder types; run pnpm gen:db after updating Supabase schema
-  public: Record<string, unknown>;
+  public: {
+    Tables: {
+      org: {
+        Row: {
+          id: number;
+          name: string;
+          created_at: string;
+        };
+        Insert: {
+          id?: number;
+          name: string;
+          created_at?: string;
+        };
+        Update: {
+          id?: number;
+          name?: string;
+          created_at?: string;
+        };
+      };
+      savings_event: {
+        Row: {
+          id: string;
+          org_id: number;
+          ts: string;
+          cloud: string | null;
+          region: string | null;
+          sku: string | null;
+          kwh: number | null;
+          usd: number | null;
+          kg: number | null;
+          note: string | null;
+        };
+        Insert: {
+          id?: string;
+          org_id: number;
+          ts?: string;
+          cloud?: string | null;
+          region?: string | null;
+          sku?: string | null;
+          kwh?: number | null;
+          usd?: number | null;
+          kg?: number | null;
+          note?: string | null;
+        };
+        Update: {
+          id?: string;
+          org_id?: number;
+          ts?: string;
+          cloud?: string | null;
+          region?: string | null;
+          sku?: string | null;
+          kwh?: number | null;
+          usd?: number | null;
+          kg?: number | null;
+          note?: string | null;
+        };
+      };
+      sku_catalogue: {
+        Row: {
+          cloud: string | null;
+          region: string | null;
+          sku: string | null;
+          watts: number | null;
+          usd_hour: number | null;
+        };
+        Insert: {
+          cloud?: string | null;
+          region?: string | null;
+          sku?: string | null;
+          watts?: number | null;
+          usd_hour?: number | null;
+        };
+        Update: {
+          cloud?: string | null;
+          region?: string | null;
+          sku?: string | null;
+          watts?: number | null;
+          usd_hour?: number | null;
+        };
+      };
+      api_key: {
+        Row: {
+          id: string;
+          org_id: number;
+          secret: string;
+          label: string | null;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          org_id: number;
+          secret: string;
+          label?: string | null;
+          created_at?: string;
+        };
+        Update: {
+          id?: string;
+          org_id?: number;
+          secret?: string;
+          label?: string | null;
+          created_at?: string;
+        };
+      };
+      activity_log: {
+        Row: {
+          id: string;
+          repo: string;
+          ts: string;
+          actor_id: string | null;
+          action: string | null;
+          meta: Json | null;
+        };
+        Insert: {
+          id?: string;
+          repo: string;
+          ts?: string;
+          actor_id?: string | null;
+          action?: string | null;
+          meta?: Json | null;
+        };
+        Update: {
+          id?: string;
+          repo?: string;
+          ts?: string;
+          actor_id?: string | null;
+          action?: string | null;
+          meta?: Json | null;
+        };
+      };
+    };
+    Functions: {
+      ledger_summary: {
+        Args: {
+          p_org: number;
+        };
+        Returns: {
+          total_usd: number | null;
+          total_kg: number | null;
+        };
+      };
+    };
+  };
 }

--- a/backend/tests/events.test.ts
+++ b/backend/tests/events.test.ts
@@ -1,0 +1,25 @@
+import { buildServer } from '../src/api';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const app = buildServer();
+const token = 'demo-secret';
+
+beforeAll(async () => {
+  await app.inject({
+    method: 'POST',
+    url:    '/v1/events',
+    headers:{ Authorization:`Bearer ${token}`,'content-type':'application/json' },
+    payload:[{cloud:'aws',region:'eu-central-1',sku:'t3.micro',kwh:0.2,usd:0.02,kg:0.15}]
+  });
+});
+
+afterAll(() => app.close());
+
+describe('summary reflects event', () => {
+  it('/v1/summary?org=1 adds up', async () => {
+    const res = await app.inject({ method:'GET', url:'/v1/summary?org=1' });
+    const body = JSON.parse(res.payload);
+    expect(body.total_kg).toBeGreaterThan(0);
+    expect(body.total_usd).toBeGreaterThan(0);
+  });
+});

--- a/iac-advisor-action/dist/index.js
+++ b/iac-advisor-action/dist/index.js
@@ -1,0 +1,63 @@
+const core = require('@actions/core');
+const github = require('@actions/github');
+const fs = require('fs');
+const fetch = require('node-fetch');
+
+function parsePlan(path) {
+  const plan = JSON.parse(fs.readFileSync(path, 'utf8'));
+  const resources = [];
+  plan.resource_changes?.forEach(rc => {
+    if (rc.change.actions.includes('create')) {
+      const provReg = rc.address.split('.')[0];
+      const [, provider] = provReg.split('_');
+      resources.push({
+        provider,
+        region: rc.change.after.availability_zone.replace(/[a-z]$/,''),
+        sku: rc.change.after.instance_type
+      });
+    }
+  });
+  return resources;
+}
+
+async function suggest(resources, api) {
+  const skus = await fetch(`${api}/v1/skus`).then(r => r.json());
+  const table = new Map(skus.map(s => [`${s.cloud}/${s.region}/${s.sku}`, s]));
+  return resources.map(r => {
+    const base = table.get(`${r.provider}/${r.region}/${r.sku}`);
+    const altSku = r.sku.replace(/medium/,'small');
+    const alt = table.get(`${r.provider}/${r.region}/${altSku}`) || base;
+    const deltaKg = ((base.watts - alt.watts) / 1000) * 0.7;
+    const deltaUsd = (base.usd_hour - alt.usd_hour) * 730;
+    return { ...r, altSku, deltaKg, deltaUsd };
+  }).filter(s => s.deltaKg > 0.1);
+}
+
+async function run() {
+  try {
+    const api = core.getInput('api-url');
+    core.getInput('api-key');
+    const plan = core.getInput('plan-json');
+    const resources = parsePlan(plan);
+    const sugg = await suggest(resources, api);
+    if (!sugg.length) {
+      core.info('No greener alternatives found.');
+      return;
+    }
+    const markdown = [
+      `### \u2618\uFE0F VerdLedger suggestions`,
+      '| Current | Greener | \u0394 kg CO\u2082 | \u0394 Cost |',
+      '|---------|---------|---------|-------|',
+      ...sugg.map(s => `| \`${s.sku}\` | \`${s.altSku}\` | **${s.deltaKg.toFixed(2)}** | **$${s.deltaUsd.toFixed(2)}** |`)
+    ].join('\n');
+    const token = process.env.GITHUB_TOKEN;
+    const octo = github.getOctokit(token);
+    const { owner, repo, number } = github.context.issue;
+    await octo.rest.issues.createComment({ owner, repo, issue_number: number, body: markdown });
+    core.setOutput('suggestions', JSON.stringify(sugg));
+  } catch (err) {
+    core.setFailed(err.message);
+  }
+}
+
+run();

--- a/supabase/migrations/20250629090000_ledger_summary_fn.sql
+++ b/supabase/migrations/20250629090000_ledger_summary_fn.sql
@@ -1,0 +1,9 @@
+create or replace function public.ledger_summary(p_org bigint)
+returns table(total_usd numeric, total_kg numeric) as $$
+begin
+  return query
+  select  coalesce(sum(usd),0), coalesce(sum(kg),0)
+  from    public.savings_event
+  where   org_id = p_org;
+end;
+$$ language plpgsql stable security definer;


### PR DESCRIPTION
## Summary
- add ledger_summary SQL function
- regenerate db types with ledger_summary
- expose /v1/summary via RPC
- add events/summary test
- include build artifact for IaC Advisor action
- readme quickstart snippet

## Testing
- `pnpm -F backend test -- --run` *(fails: vitest not found)*
- `pnpm -F iac-advisor-action test -- --run` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861268f08d4832283f0e1672ed5ba71