### PR TITLE
Type supabase clients

### DIFF
--- a/backend/src/api/routes/events.ts
+++ b/backend/src/api/routes/events.ts
@@ -1,11 +1,13 @@
 import { FastifyInstance } from 'fastify';
 import { z } from 'zod';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '../../db-types';
 // export const eventsRoute =
-//   (sb: any) => async (app: FastifyInstance) => {
+//   (sb: SupabaseClient<Database>) => async (app: FastifyInstance) => {
 
 
 export const eventsRoute =
-  (sb: any) => async (app: FastifyInstance) => {
+  (sb: SupabaseClient<Database>) => async (app: FastifyInstance) => {
  // ① list events (public, read-only, org filter)
  app.get('/', async (req, res) => {
    const { org, limit = '25', offset = '0' } = req.query as Record<string, string>;

--- a/backend/src/api/routes/skus.ts
+++ b/backend/src/api/routes/skus.ts
@@ -1,6 +1,8 @@
 import { FastifyInstance, FastifyPluginOptions } from 'fastify';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '../../db-types';
 export const skusRoute =
-  (sb: any) => async (app: FastifyInstance, _opts: FastifyPluginOptions) => {
+  (sb: SupabaseClient<Database>) => async (app: FastifyInstance, _opts: FastifyPluginOptions) => {
 
   app.get('/', async (_req, res) => {
     const { data, error } = await sb

--- a/backend/src/api/routes/summary.ts
+++ b/backend/src/api/routes/summary.ts
@@ -1,6 +1,8 @@
 import { FastifyInstance } from 'fastify';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '../../db-types';
 export const summaryRoute =
-  (sb: any) => async (app: FastifyInstance) => {
+  (sb: SupabaseClient<Database>) => async (app: FastifyInstance) => {
 
   app.get('/', async (req, res) => {
     const org = Number((req.query as any).org);

--- a/backend/src/api/routes/tokens.ts
+++ b/backend/src/api/routes/tokens.ts
@@ -1,8 +1,10 @@
 import { randomUUID } from 'node:crypto';
 import { FastifyInstance } from 'fastify';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '../../db-types';
 
 export const tokensRoute =
-  (sb: any) => async (app: FastifyInstance) => {
+  (sb: SupabaseClient<Database>) => async (app: FastifyInstance) => {
 
   app.post('/', async (req, res) => {
     const { org } = req.body as { org?: number };


### PR DESCRIPTION
## Summary
- type supabase clients in API route files

## Testing
- `pnpm -r --parallel test -- --run` *(fails: cannot reach npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68642ce46c108322afd9ecbe529a6fd3