### PR TITLE
Add JWT auth wrappers

### DIFF
--- a/backend/src/api/routes/tokens.ts
+++ b/backend/src/api/routes/tokens.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { FastifyInstance } from 'fastify';
+import { sign } from '../../lib/jwt';
 
 export const tokensRoute =
   (sb: any) => async (app: FastifyInstance) => {
@@ -8,14 +9,14 @@ export const tokensRoute =
     const { org } = req.body as { org?: number };
     if (!org) return res.badRequest('org required');
 
-    const secret = randomUUID().replace(/-/g,'');
-    const { data, error } = await sb
+    const secret = randomUUID().replace(/-/g, '');
+    const { error } = await sb
       .from('api_key')
-      .insert({ org_id: org, secret, label: 'dashboard' })
-      .select('secret')
-      .single();
+      .insert({ org_id: org, secret, label: 'dashboard' });
 
     if (error) return res.internalServerError(error);
-    res.send(data);          // { secret: "…" }
+
+    const token = sign({ key: secret });
+    res.send({ token });
   });
 };

--- a/backend/src/lib/jwt.ts
+++ b/backend/src/lib/jwt.ts
@@ -1,0 +1,9 @@
+import jwt from 'jsonwebtoken';
+
+const secret = process.env.VERDLEDGER_JWT_SECRET || 'change_me';
+
+export const sign = (payload: string | object | Buffer) =>
+  jwt.sign(payload, secret);
+
+export const verify = <T extends object | string>(token: string) =>
+  jwt.verify(token, secret) as T;

--- a/backend/tests/events.test.ts
+++ b/backend/tests/events.test.ts
@@ -1,8 +1,9 @@
 import { buildServer } from '../src/api';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { sign } from '../src/lib/jwt';
 
 const app = buildServer();
-const token = 'demo-secret';
+const token = sign({ key: 'demo-secret' });
 
 beforeAll(async () => {
   await app.inject({

--- a/backend/tests/pagination.test.ts
+++ b/backend/tests/pagination.test.ts
@@ -1,5 +1,6 @@
 import { buildServer } from '../src/api';
 import { describe, it, expect } from 'vitest';
+import { sign } from '../src/lib/jwt';
 
 const app = buildServer();
 
@@ -9,7 +10,7 @@ describe('event list pagination', () => {
     await app.inject({
       method: 'POST',
       url: '/v1/events',
-      headers: { Authorization: 'Bearer demo-secret' },
+      headers: { Authorization: `Bearer ${sign({ key: 'demo-secret' })}` },
       payload: Array.from({ length: 30 }).map(() => ({
         cloud: 'aws', region: 'eu-central-1', sku: 't3.micro',
         kwh: 0.1, usd: 0.01, kg: 0.07

--- a/backend/tests/tokens.test.ts
+++ b/backend/tests/tokens.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect } from 'vitest';
 const app = buildServer();
 
 describe('POST /v1/tokens', () => {
-  it('creates unique secrets', async () => {
+  it('creates unique tokens', async () => {
     const run = async () =>
       app.inject({
         method: 'POST',
@@ -17,7 +17,7 @@ describe('POST /v1/tokens', () => {
 
     expect(a.statusCode).toBe(200);
     expect(b.statusCode).toBe(200);
-    expect(JSON.parse(a.payload).secret)
-      .not.toBe(JSON.parse(b.payload).secret);
+    expect(JSON.parse(a.payload).token)
+      .not.toBe(JSON.parse(b.payload).token);
   });
 });


### PR DESCRIPTION
## Summary
- implement simple jwt helpers
- issue JWTs from token route
- verify JWTs on protected event route
- adapt backend tests to use tokens

## Testing
- `pnpm test:unit` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68642d15bd8083228ff78af0b7b81d23