### PR TITLE
Add package step for iac-advisor action

### DIFF
--- a/.github/workflows/action-ci.yml
+++ b/.github/workflows/action-ci.yml
@@ -24,3 +24,4 @@ jobs:
       - run: pnpm install
       - run: pnpm -F iac-advisor-action test          # Vitest
       - run: pnpm -F iac-advisor-action build         # bundles dist/index.js
+      - run: pnpm -F iac-advisor-action package       # packages action


### PR DESCRIPTION
## Summary
- update GitHub Actions workflow for iac-advisor-action

## Testing
- `pnpm -F iac-advisor-action test` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_68642d2f93dc8322a5602c6baf572df5