### PR TITLE
Add script to post savings events

### DIFF
--- a/.github/workflows/iac-advisor.yml
+++ b/.github/workflows/iac-advisor.yml
@@ -1,16 +1,24 @@
 name: IaC Advisor
 on: [pull_request]
+
 jobs:
-  advisor:
+  advise:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Lint Terraform
+      - uses: hashicorp/setup-terraform@v3
+      - run: terraform init
+      - run: terraform plan -out=plan
+      - run: terraform show -json plan > plan.json
+      - id: advice
+        uses: verdledger/iac-advisor-action@v0.1.0
+        with:
+          plan-json: plan.json
+          api-key: ${{ secrets.VERDLEDGER_KEY }}
+      - name: Post savings
+        if: contains(github.event.pull_request.labels.*.name, 'verdledger:apply')
         run: |
-          echo "Linting Terraform..."
-          # placeholder for terraform lint
-      - name: Suggest greener alternatives
-        run: |
-          echo "Compute savings..."
-          echo "kWh saved: 0"
-          echo "CO2 saved: 0"
+          node iac-advisor-action/post-savings.js \
+            '${{ steps.advice.outputs.suggestions }}' \
+            https://api.verdledger.dev \
+            ${{ secrets.VERDLEDGER_KEY }}

--- a/iac-advisor-action/README.md
+++ b/iac-advisor-action/README.md
@@ -1,10 +1,19 @@
 # VerdLedger IaC Advisor Action
 
-Comment estimated cost and CO\u2082 savings on Terraform pull requests.
+Comment estimated cost and CO₂ savings on Terraform pull requests. When a PR is merged with the label `verdledger:apply` you can record the accepted savings using `post-savings.js`.
 
 ```yaml
 - uses: verdledger/iac-advisor-action@v0.1.0
+  id: advise
   with:
     plan-json: plan.json
     api-key: ${{ secrets.VERDLEDGER_KEY }}
+```
+
+Post the savings to your VerdLedger account:
+
+```yaml
+- name: Post savings
+  if: contains(github.event.pull_request.labels.*.name, 'verdledger:apply')
+  run: node iac-advisor-action/post-savings.js '\${{ steps.advise.outputs.suggestions }}' https://api.verdledger.dev \${{ secrets.VERDLEDGER_KEY }}
 ```

--- a/iac-advisor-action/post-savings.js
+++ b/iac-advisor-action/post-savings.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+// Post accepted VerdLedger suggestions to the API ledger
+// Usage: node post-savings.js '<suggestions-json>' [api-url] <api-key>
+
+const [suggJson, api = 'https://api.verdledger.dev', key] = process.argv.slice(2);
+
+if (!suggJson || !key) {
+  console.error('Usage: node post-savings.js "<suggestions-json>" [api-url] <api-key>');
+  process.exit(1);
+}
+
+let suggestions;
+try {
+  suggestions = JSON.parse(suggJson);
+} catch (err) {
+  console.error('Invalid suggestions JSON');
+  process.exit(1);
+}
+
+const events = suggestions.map(s => ({
+  cloud: s.provider,
+  region: s.region,
+  sku: s.altSku,
+  kwh: +(s.deltaKg / 0.7).toFixed(3),
+  usd: +s.deltaUsd.toFixed(2),
+  kg: +s.deltaKg.toFixed(2)
+}));
+
+(async () => {
+  const res = await fetch(`${api}/v1/events`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${key}`
+    },
+    body: JSON.stringify(events)
+  });
+
+  if (!res.ok) {
+    console.error('Error:', await res.text());
+    process.exit(1);
+  }
+
+  console.log(`Inserted ${events.length} event${events.length === 1 ? '' : 's'}`);
+})();


### PR DESCRIPTION
## Summary
- add `post-savings.js` for sending accepted suggestions to the API
- document how to record savings
- illustrate usage in `iac-advisor.yml`

## Testing
- `pnpm -F iac-advisor-action test --run` *(fails: Request to registry.npmjs.org blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68642d56cc0083229976f92b5bb782bb