### PR TITLE
Fix API key response and display

### DIFF
--- a/backend/src/api/routes/tokens.ts
+++ b/backend/src/api/routes/tokens.ts
@@ -19,6 +19,6 @@ export const tokensRoute =
     if (error) return res.internalServerError(error);
 
     const token = sign({ key: secret });
-    res.send({ token });
+    res.send({ secret: token });
   });
 };

--- a/backend/tests/tokens.test.ts
+++ b/backend/tests/tokens.test.ts
@@ -17,7 +17,7 @@ describe('POST /v1/tokens', () => {
 
     expect(a.statusCode).toBe(200);
     expect(b.statusCode).toBe(200);
-    expect(JSON.parse(a.payload).token)
-      .not.toBe(JSON.parse(b.payload).token);
+    expect(JSON.parse(a.payload).secret)
+      .not.toBe(JSON.parse(b.payload).secret);
   });
 });

--- a/frontend/src/components/ApiKeyBlock.client.tsx
+++ b/frontend/src/components/ApiKeyBlock.client.tsx
@@ -27,10 +27,11 @@ export default function ApiKeyBlock({ orgId }: { orgId: number }) {
       ) : (
         <>
           <pre className="bg-slate-900 text-white text-sm p-3 rounded mb-2">
-- uses: verdledger/iac-advisor-action@v0.1.0
+{`- uses: verdledger/iac-advisor-action@v0.1.0
   with:
     api-url: https://api.verdledger.dev
-    api-key: {key}
+    api-key: ${key}
+`}
           </pre>
           <p className="text-xs text-slate-600">
             Copy this into your <code>.github/workflows/*.yml</code> file.


### PR DESCRIPTION
## Summary
- return `{ secret }` from the token route
- expect `secret` in token tests
- show generated secret in the dashboard snippet

## Testing
- `pnpm test:unit` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6864374ba55c83229bd92c47b2a42b89