### PR TITLE
Fix frontend API env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,8 @@ pnpm --filter backend dev
 ```
 
 Then visit `http://localhost:4000/health` to verify the server is running.
+
+## Dashboard configuration
+
+The frontend reads `NEXT_PUBLIC_API_URL` from `.env.local` to know where to
+fetch data. In production this is `https://api.verdledger.dev`.

--- a/frontend/.env.local
+++ b/frontend/.env.local
@@ -1,1 +1,2 @@
 NEXT_PUBLIC_API_URL=https://api.verdledger.dev
+

--- a/frontend/src/lib/env.ts
+++ b/frontend/src/lib/env.ts
@@ -1,6 +1,6 @@
 /**
  * Central place for environment constants.
- * Use NEXT_PUBLIC_VERD_API_URL in prod; fall back to local Fastify.
+ * Use NEXT_PUBLIC_API_URL in prod; fall back to local Fastify.
  */
 export const API =
-  process.env.NEXT_PUBLIC_VERD_API_URL ?? 'http://localhost:4000';
+  process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:4000';


### PR DESCRIPTION
## Summary
- fix env var name in `frontend/src/lib/env.ts`
- add newline to `.env.local`
- document the API env var in README

## Testing
- `pnpm test:unit` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68643750cd508322bdd17ef9e2fc003b