### PR TITLE
Fix workflow key snippet

### DIFF
--- a/frontend/src/components/ApiKeyBlock.client.tsx
+++ b/frontend/src/components/ApiKeyBlock.client.tsx
@@ -26,12 +26,10 @@ export default function ApiKeyBlock({ orgId }: { orgId: number }) {
         </button>
       ) : (
         <>
-          <pre className="bg-slate-900 text-white text-sm p-3 rounded mb-2">
-- uses: verdledger/iac-advisor-action@v0.1.0
+          <pre className="bg-slate-900 text-white text-sm p-3 rounded mb-2">{`- uses: verdledger/iac-advisor-action@v0.1.0
   with:
     api-url: https://api.verdledger.dev
-    api-key: {key}
-          </pre>
+    api-key: ${key}`}</pre>
           <p className="text-xs text-slate-600">
             Copy this into your <code>.github/workflows/*.yml</code> file.
           </p>


### PR DESCRIPTION
## Summary
- use a template string so the generated API key is shown in the snippet

## Testing
- `pnpm test:unit` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.15.9.tgz)*

------
https://chatgpt.com/codex/tasks/task_e_6864375423f883229e4aa1f128f4b45f