### PR TITLE
Disable server actions

### DIFF
--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'url';
 const nextConfig = {
   experimental: {
     // boolean form is gone in Next 15—wrap it in an object:
-    serverActions: { enabled: true }
+    serverActions: { enabled: false }
   },
 
   // Local proxy: /api/* → Fastify on :4000


### PR DESCRIPTION
## Summary
- disable server actions in `frontend/next.config.mjs`

## Testing
- `pnpm --filter frontend build` *(fails: Request was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68643759b6388322a6d700e631f9d809