### PR TITLE
Implement Sprint 2 CLI and carbon estimator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,9 @@ dev:	## start db + api
 
 test:	## run Go tests
 	go test ./... -v
+
+cli:	## build static CLI binary
+	go build -o bin/verdledger ./cmd/cli
+
+scan: cli	## example scan run
+	./bin/verdledger scan testdata/plan.json

--- a/cmd/advisor-action/action.yml
+++ b/cmd/advisor-action/action.yml
@@ -1,0 +1,8 @@
+name: VerdLedger IaC Advisor (alpha)
+runs:
+  using: docker
+  image: docker://ghcr.io/verdledger/advisor-action:v0.1.0
+inputs:
+  path:
+    description: "Path to plan JSON"
+    required: true

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+    "os"
+
+    "github.com/spf13/cobra"
+)
+
+var root = &cobra.Command{
+    Use:   "verdledger",
+    Short: "VerdLedger CLI – carbon-aware IaC tools",
+}
+
+func main() {
+    root.AddCommand(cmdScan())
+    if err := root.Execute(); err != nil {
+        os.Exit(1)
+    }
+}

--- a/cmd/cli/scan.go
+++ b/cmd/cli/scan.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+    "bytes"
+    "encoding/json"
+    "fmt"
+    "io"
+    "net/http"
+    "os"
+
+    "github.com/jedib0t/go-pretty/v6/table"
+    "github.com/spf13/cobra"
+    "github.com/verdledger/verdledger/internal/carbon"
+    "github.com/verdledger/verdledger/internal/iac"
+)
+
+func cmdScan() *cobra.Command {
+    var (
+        org     int64
+        project int64
+        push    bool
+        apiURL  string
+    )
+
+    c := &cobra.Command{
+        Use:   "scan <plan.json>",
+        Short: "Analyse a Terraform plan JSON for carbon impact",
+        Args:  cobra.ExactArgs(1),
+        RunE: func(_ *cobra.Command, args []string) error {
+            resources, err := iac.ParsePlan(args[0])
+            if err != nil { return err }
+
+            results := carbon.Estimate(resources)
+
+            // ------- pretty table ----------
+            t := table.NewWriter()
+            t.SetOutputMirror(os.Stdout)
+            t.AppendHeader(table.Row{
+                "RESOURCE", "SKU", "REGION", "kWh/yr", "kg CO₂/yr"})
+            for _, r := range results {
+                t.AppendRow(table.Row{
+                    r.Address, r.SKU, r.Region,
+                    fmt.Sprintf("%.0f", r.KWhAnnual),
+                    fmt.Sprintf("%.1f", r.KgAnnual),
+                })
+            }
+            t.Render()
+
+            if push {
+                return pushEvents(apiURL, org, project, results)
+            }
+            return nil
+        },
+    }
+
+    c.Flags().Int64Var(&org, "org", 0, "Org ID when pushing")
+    c.Flags().Int64Var(&project, "project", 0, "Project ID when pushing")
+    c.Flags().BoolVar(&push, "push", false, "Send results to VerdLedger API")
+    c.Flags().StringVar(&apiURL, "api", "http://localhost:8080", "API base URL")
+    return c
+}
+
+func pushEvents(api string, org, project int64, results []carbon.Result) error {
+    for _, r := range results {
+        body, _ := json.Marshal(map[string]any{
+            "org_id":     org,
+            "project_id": project,
+            "cloud":      r.Provider,
+            "region":     r.Region,
+            "sku":        r.SKU,
+            "kwh":        r.KWhAnnual,
+            "usd":        0,
+            "kg":         r.KgAnnual,
+            "note":       "cli scan",
+        })
+        resp, err := http.Post(api+"/v1/events",
+            "application/json", io.NopCloser(
+                bytes.NewReader(body)))
+        if err != nil { return err }
+        defer resp.Body.Close()
+        if resp.StatusCode != 201 {
+            return fmt.Errorf("API error %d", resp.StatusCode)
+        }
+    }
+    fmt.Println("✔ pushed", len(results), "events")
+    return nil
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,10 @@ go 1.23.0
 toolchain go1.24.4
 
 require (
-	github.com/go-chi/chi/v5 v5.2.2
-	github.com/google/uuid v1.6.0
-	github.com/sqlc-dev/pqtype v0.3.0
+        github.com/go-chi/chi/v5 v5.2.2
+        github.com/google/uuid v1.6.0
+        github.com/sqlc-dev/pqtype v0.3.0
+       github.com/hashicorp/terraform-json v1.5.0
+       github.com/jedib0t/go-pretty/v6 v6.4.4
+       github.com/spf13/cobra v1.7.0
 )

--- a/internal/carbon/estimator.go
+++ b/internal/carbon/estimator.go
@@ -1,0 +1,44 @@
+package carbon
+
+import (
+    "time"
+
+    "github.com/verdledger/verdledger/internal/iac"
+)
+
+// Static factors for sprint-2 POC
+var regionFactor = map[string]float64{
+    "us-west-2": 0.409,
+    "eu-west-1": 0.220,
+}
+
+const wattsPerVCpu = 15
+
+type Result struct {
+    iac.Resource
+    KWhAnnual float64
+    KgAnnual  float64
+}
+
+// Estimate converts CPU → kWh → kg CO₂ (1 yr 24×7).
+func Estimate(rs []iac.Resource) []Result {
+    var out []Result
+    hoursYear := 24 * 365
+
+    for _, r := range rs {
+        watts := r.VCPU * wattsPerVCpu
+        kwh := (watts * float64(hoursYear)) / 1000
+        kg := kwh * regionFactor[r.Region]
+
+        out = append(out, Result{
+            Resource:  r,
+            KWhAnnual: kwh,
+            KgAnnual:  kg,
+        })
+    }
+    return out
+}
+
+// Timestamp helper for events
+func NowUTC() time.Time { return time.Now().UTC() }
+

--- a/internal/carbon/estimator_test.go
+++ b/internal/carbon/estimator_test.go
@@ -1,0 +1,17 @@
+package carbon_test
+
+import (
+    "testing"
+
+    "github.com/verdledger/verdledger/internal/carbon"
+    "github.com/verdledger/verdledger/internal/iac"
+)
+
+func TestEstimate(t *testing.T) {
+    in := []iac.Resource{{
+        Provider: "aws", Region: "us-west-2",
+        VCPU: 2, SKU: "t3.medium",
+    }}
+    r := carbon.Estimate(in)[0]
+    if r.KgAnnual == 0 { t.Fatal("got 0 kg") }
+}

--- a/internal/iac/parser.go
+++ b/internal/iac/parser.go
@@ -1,0 +1,69 @@
+package iac
+
+import (
+    "encoding/json"
+    "os"
+    "strings"
+
+    tfjson "github.com/hashicorp/terraform-json"
+)
+
+// Resource is the distilled info VerdLedger needs.
+type Resource struct {
+    Address string
+    Provider, Region, SKU string
+    VCPU, MemoryGB        float64
+}
+
+// ParsePlan reads a "terraform show -json" dump and returns resources.
+func ParsePlan(path string) ([]Resource, error) {
+    raw, err := os.ReadFile(path)
+    if err != nil { return nil, err }
+
+    var plan tfjson.Plan
+    if err = json.Unmarshal(raw, &plan); err != nil { return nil, err }
+
+    var out []Resource
+    for _, rc := range plan.ResourceChanges {
+        // Only look at "create" or "update" actions
+        if !contains(rc.Change.Actions, "create") &&
+            !contains(rc.Change.Actions, "update") {
+            continue
+        }
+
+        // Example address: aws_instance.web[0]
+        provider := strings.Split(rc.Address, "_")[0]
+
+        // Try to pull instance_type and region
+        after := rc.Change.After.(map[string]any)
+        region, _ := after["availability_zone"].(string)
+        sku, _    := after["instance_type"].(string)
+
+        // VERY rough CPU/memory extraction for AWS EC2
+        var vcpu, mem float64
+        if provider == "aws" && sku != "" {
+            switch {
+            case strings.HasPrefix(sku, "t3a."):
+                vcpu, mem = 2, 4
+            case strings.HasPrefix(sku, "t3."):
+                vcpu, mem = 2, 4
+            }
+        }
+
+        out = append(out, Resource{
+            Address:  rc.Address,
+            Provider: provider,
+            Region:   region,
+            SKU:      sku,
+            VCPU:     vcpu,
+            MemoryGB: mem,
+        })
+    }
+    return out, nil
+}
+
+func contains(arr []string, v string) bool {
+    for _, a := range arr { if a == v { return true } }
+    return false
+}
+

--- a/internal/iac/parser_test.go
+++ b/internal/iac/parser_test.go
@@ -1,0 +1,14 @@
+package iac_test
+
+import (
+    "testing"
+
+    "github.com/verdledger/verdledger/internal/iac"
+)
+
+func TestParsePlan(t *testing.T) {
+    rs, err := iac.ParsePlan("../../testdata/plan.json")
+    if err != nil { t.Fatal(err) }
+    if len(rs) != 1 { t.Fatalf("want 1 got %d", len(rs)) }
+    if rs[0].SKU != "t3.medium" { t.Fatalf("bad SKU") }
+}

--- a/testdata/plan.json
+++ b/testdata/plan.json
@@ -1,0 +1,20 @@
+{
+  "format_version": "1.1",
+  "terraform_version": "1.7.5",
+  "resource_changes": [
+    {
+      "address": "aws_instance.app",
+      "mode": "managed",
+      "type": "aws_instance",
+      "name": "app",
+      "provider_name": "registry.terraform.io/hashicorp/aws",
+      "change": {
+        "actions": ["create"],
+        "after": {
+          "availability_zone": "us-west-2a",
+          "instance_type": "t3.medium"
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add Terraform plan parser and stub carbon estimator
- provide CLI implementation with Cobra
- include smoke tests for the new packages
- add VerdLedger advisor GitHub Action skeleton
- update Makefile and add example Terraform plan

## Testing
- `make cli` *(fails: missing go.sum entries due to no network)*
- `make scan` *(fails: missing go.sum entries due to no network)*
- `go test ./... -v` *(fails: unable to fetch modules)*

------
https://chatgpt.com/codex/tasks/task_e_686d980ad64c8330b41c2da2c2b6f23b