### PR TITLE
Add VerdLedger GitHub action & container

### DIFF
--- a/.github/workflows/release-action.yml
+++ b/.github/workflows/release-action.yml
@@ -1,0 +1,35 @@
+name: Release VerdLedger Action
+
+on:
+  push:
+    tags: ["v*.*.*"]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build & push
+        uses: docker/build-push-action@v5
+        with:
+          context: ./cmd/advisor-action
+          platforms: linux/amd64
+          tags: ghcr.io/${{ github.repository_owner }}/verdledger-action:${{ github.ref_name }}
+          push: true

--- a/cmd/advisor-action/Dockerfile
+++ b/cmd/advisor-action/Dockerfile
@@ -1,0 +1,13 @@
+# ---------- build stage ----------
+FROM golang:1.24-bullseye AS build
+WORKDIR /src
+COPY go.* ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o /out/verdledger ./cmd/cli
+
+# ---------- final ----------
+FROM gcr.io/distroless/static-debian11
+LABEL org.opencontainers.image.source="https://github.com/verdledger/verdledger"
+COPY --from=build /out/verdledger /usr/local/bin/verdledger
+ENTRYPOINT ["/usr/local/bin/verdledger"]

--- a/cmd/advisor-action/action.yml
+++ b/cmd/advisor-action/action.yml
@@ -1,8 +1,38 @@
-name: VerdLedger IaC Advisor (alpha)
-runs:
-  using: docker
-  image: docker://ghcr.io/verdledger/advisor-action:v0.1.0
+name: VerdLedger IaC Advisor
+description: Scan a Terraform plan for carbon impact, comment results, and (optionally) push to VerdLedger.
+branding:
+  icon: leaf
+  color: green
+
 inputs:
   path:
-    description: "Path to plan JSON"
+    description: "Path to plan JSON (terraform show -json)"
     required: true
+  org:
+    description: "VerdLedger org ID (for --push)"
+    required: false
+  project:
+    description: "VerdLedger project ID (for --push)"
+    required: false
+  api-url:
+    description: "VerdLedger API base URL"
+    required: false
+    default: "https://api.verdledger.dev"
+  api-key:
+    description: "Bearer token for the API (header: Authorization)"
+    required: false
+  push:
+    description: "true to send events to VerdLedger"
+    required: false
+    default: "false"
+
+runs:
+  using: "docker"
+  image: "ghcr.io/verdledger/verdledger-action:v0.1.0"
+  args:
+    - scan
+    - ${{ inputs.path }}
+    - "--org=${{ inputs.org }}"
+    - "--project=${{ inputs.project }}"
+    - "--api=${{ inputs.api-url }}"
+    - ${{ inputs.push == 'true' && '--push' || '' }}

--- a/cmd/cli/github.go
+++ b/cmd/cli/github.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+
+	"golang.org/x/oauth2"
+)
+
+func postComment(token string, pr int, md string) error {
+	ctx := context.Background()
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token})
+	tc := oauth2.NewClient(ctx, ts)
+
+	body := bytes.NewBufferString(
+		fmt.Sprintf(`{"body":%q}`, md))
+	req, _ := http.NewRequest("POST",
+		fmt.Sprintf("https://api.github.com/repos/${GITHUB_REPOSITORY}/issues/%d/comments", pr),
+		body)
+	req.Header.Set("Content-Type", "application/json")
+	res, err := tc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+	if res.StatusCode >= 300 {
+		return fmt.Errorf("comment failed %d", res.StatusCode)
+	}
+	return nil
+}

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -1,19 +1,19 @@
 package main
 
 import (
-    "os"
+	"os"
 
-    "github.com/spf13/cobra"
+	"github.com/spf13/cobra"
 )
 
 var root = &cobra.Command{
-    Use:   "verdledger",
-    Short: "VerdLedger CLI – carbon-aware IaC tools",
+	Use:   "verdledger",
+	Short: "VerdLedger CLI – carbon-aware IaC tools",
 }
 
 func main() {
-    root.AddCommand(cmdScan())
-    if err := root.Execute(); err != nil {
-        os.Exit(1)
-    }
+	root.AddCommand(cmdScan())
+	if err := root.Execute(); err != nil {
+		os.Exit(1)
+	}
 }

--- a/cmd/cli/scan.go
+++ b/cmd/cli/scan.go
@@ -1,87 +1,103 @@
 package main
 
 import (
-    "bytes"
-    "encoding/json"
-    "fmt"
-    "io"
-    "net/http"
-    "os"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
 
-    "github.com/jedib0t/go-pretty/v6/table"
-    "github.com/spf13/cobra"
-    "github.com/verdledger/verdledger/internal/carbon"
-    "github.com/verdledger/verdledger/internal/iac"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/spf13/cobra"
+	"github.com/verdledger/verdledger/internal/carbon"
+	"github.com/verdledger/verdledger/internal/iac"
 )
 
 func cmdScan() *cobra.Command {
-    var (
-        org     int64
-        project int64
-        push    bool
-        apiURL  string
-    )
+	var (
+		org     int64
+		project int64
+		push    bool
+		apiURL  string
+		comment bool
+		ghToken string
+		prID    int
+	)
 
-    c := &cobra.Command{
-        Use:   "scan <plan.json>",
-        Short: "Analyse a Terraform plan JSON for carbon impact",
-        Args:  cobra.ExactArgs(1),
-        RunE: func(_ *cobra.Command, args []string) error {
-            resources, err := iac.ParsePlan(args[0])
-            if err != nil { return err }
+	c := &cobra.Command{
+		Use:   "scan <plan.json>",
+		Short: "Analyse a Terraform plan JSON for carbon impact",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			resources, err := iac.ParsePlan(args[0])
+			if err != nil {
+				return err
+			}
 
-            results := carbon.Estimate(resources)
+			results := carbon.Estimate(resources)
 
-            // ------- pretty table ----------
-            t := table.NewWriter()
-            t.SetOutputMirror(os.Stdout)
-            t.AppendHeader(table.Row{
-                "RESOURCE", "SKU", "REGION", "kWh/yr", "kg CO₂/yr"})
-            for _, r := range results {
-                t.AppendRow(table.Row{
-                    r.Address, r.SKU, r.Region,
-                    fmt.Sprintf("%.0f", r.KWhAnnual),
-                    fmt.Sprintf("%.1f", r.KgAnnual),
-                })
-            }
-            t.Render()
+			// ------- pretty table ----------
+			t := table.NewWriter()
+			t.SetOutputMirror(os.Stdout)
+			t.AppendHeader(table.Row{
+				"RESOURCE", "SKU", "REGION", "kWh/yr", "kg CO₂/yr"})
+			for _, r := range results {
+				t.AppendRow(table.Row{
+					r.Address, r.SKU, r.Region,
+					fmt.Sprintf("%.0f", r.KWhAnnual),
+					fmt.Sprintf("%.1f", r.KgAnnual),
+				})
+			}
+			t.Render()
 
-            if push {
-                return pushEvents(apiURL, org, project, results)
-            }
-            return nil
-        },
-    }
+			if comment && ghToken != "" && prID != 0 {
+				if err := postComment(ghToken, prID, t.RenderMarkdown()); err != nil {
+					return err
+				}
+			}
 
-    c.Flags().Int64Var(&org, "org", 0, "Org ID when pushing")
-    c.Flags().Int64Var(&project, "project", 0, "Project ID when pushing")
-    c.Flags().BoolVar(&push, "push", false, "Send results to VerdLedger API")
-    c.Flags().StringVar(&apiURL, "api", "http://localhost:8080", "API base URL")
-    return c
+			if push {
+				return pushEvents(apiURL, org, project, results)
+			}
+			return nil
+		},
+	}
+
+	c.Flags().Int64Var(&org, "org", 0, "Org ID when pushing")
+	c.Flags().Int64Var(&project, "project", 0, "Project ID when pushing")
+	c.Flags().BoolVar(&push, "push", false, "Send results to VerdLedger API")
+	c.Flags().StringVar(&apiURL, "api", "http://localhost:8080", "API base URL")
+	c.Flags().BoolVar(&comment, "comment", false, "Comment results on GitHub PR")
+	c.Flags().StringVar(&ghToken, "github-token", os.Getenv("GITHUB_TOKEN"), "GitHub token")
+	c.Flags().IntVar(&prID, "pr", 0, "Pull-request number for comment")
+	return c
 }
 
 func pushEvents(api string, org, project int64, results []carbon.Result) error {
-    for _, r := range results {
-        body, _ := json.Marshal(map[string]any{
-            "org_id":     org,
-            "project_id": project,
-            "cloud":      r.Provider,
-            "region":     r.Region,
-            "sku":        r.SKU,
-            "kwh":        r.KWhAnnual,
-            "usd":        0,
-            "kg":         r.KgAnnual,
-            "note":       "cli scan",
-        })
-        resp, err := http.Post(api+"/v1/events",
-            "application/json", io.NopCloser(
-                bytes.NewReader(body)))
-        if err != nil { return err }
-        defer resp.Body.Close()
-        if resp.StatusCode != 201 {
-            return fmt.Errorf("API error %d", resp.StatusCode)
-        }
-    }
-    fmt.Println("✔ pushed", len(results), "events")
-    return nil
+	for _, r := range results {
+		body, _ := json.Marshal(map[string]any{
+			"org_id":     org,
+			"project_id": project,
+			"cloud":      r.Provider,
+			"region":     r.Region,
+			"sku":        r.SKU,
+			"kwh":        r.KWhAnnual,
+			"usd":        0,
+			"kg":         r.KgAnnual,
+			"note":       "cli scan",
+		})
+		resp, err := http.Post(api+"/v1/events",
+			"application/json", io.NopCloser(
+				bytes.NewReader(body)))
+		if err != nil {
+			return err
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != 201 {
+			return fmt.Errorf("API error %d", resp.StatusCode)
+		}
+	}
+	fmt.Println("✔ pushed", len(results), "events")
+	return nil
 }


### PR DESCRIPTION
## Summary
- build advisor action container
- publish action metadata for VerdLedger advisor
- allow the CLI to comment on pull requests
- add helper for posting comments via GitHub API
- workflow to release action container

## Testing
- `go test ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_686d99935d508330ad2db49e87d3ab23