### PR TITLE
Add Next.js 14 dashboard skeleton

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: ✅  Run Vitest suite
         run: pnpm test
 
+      - name: Playwright tests
+        run: pnpm exec playwright test
+
       # ────────────── security scanning ────────────────
       - name: 🔍 Trivy FS scan
         uses: aquasecurity/trivy-action@v0.22.0

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "turbo run dev --parallel",
     "lint": "turbo run lint",
     "test": "vitest run",
+    "test:e2e": "pnpm exec playwright test",
     "test:gold": "vitest run apps/api-server/__tests__/summary-golden.test.ts",
     "golden:update": "curl -s 'http://localhost:80/v1/summary?org=1&limit=10' > testdata/summary.golden.json"
   },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
 export default defineConfig({
-  testDir: './frontend/tests',
+  testDir: './web/tests',
   retries: 0,
   timeout: 30_000,
   use: {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,4 @@
 packages:
   - "apps/*"
   - "packages/*"
+  - "web"

--- a/web/app/_components/kpi-card.tsx
+++ b/web/app/_components/kpi-card.tsx
@@ -1,0 +1,17 @@
+import useSWR from 'swr';
+
+const fetcher = (url: string) => fetch(url).then(r => r.json());
+
+export default function KpiCard() {
+  const { data, error } = useSWR('/api/summary?org=1', fetcher, { refreshInterval: 30000 });
+
+  if (error) return <div className="card">Error loading KPIs</div>;
+  if (!data) return <div className="card animate-pulse">Loading…</div>;
+
+  return (
+    <div className="card">
+      <h2 className="text-gray-500">CO₂ Avoided</h2>
+      <p className="text-3xl font-semibold">{data.total_kg.toFixed(0)} kg</p>
+    </div>
+  );
+}

--- a/web/app/api/auth/[...supabase]/route.ts
+++ b/web/app/api/auth/[...supabase]/route.ts
@@ -1,0 +1,7 @@
+import { createClient } from '@/utils/supabase-client';
+import { NextRequest } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const supabase = createClient();
+  return await supabase.auth.api.handleAuthCallback(req);
+}

--- a/web/app/api/events/route.ts
+++ b/web/app/api/events/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  const url = `${process.env.NEXT_PUBLIC_API_URL}/v1/events${req.nextUrl.search}`;
+  const res = await fetch(url);
+  return new Response(await res.text(), { status: res.status });
+}

--- a/web/app/api/summary/route.ts
+++ b/web/app/api/summary/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  const url = `${process.env.NEXT_PUBLIC_API_URL}/v1/summary${req.nextUrl.search}`;
+  const res = await fetch(url);
+  return new Response(await res.text(), { status: res.status });
+}

--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+.card {
+  @apply p-4 border rounded bg-white shadow;
+}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,0 +1,29 @@
+import './globals.css';
+import { createClient } from '@/utils/supabase-client';
+
+export const metadata = { title: 'VerdLedger' };
+
+export default async function RootLayout({ children }: {children: React.ReactNode}) {
+  const supabase = createClient();
+  const { data } = await supabase.auth.getSession();
+
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-gray-50 text-gray-900 antialiased">
+        <nav className="px-6 h-14 flex items-center border-b">
+          <span className="font-bold text-xl text-emerald-600">VerdLedger</span>
+          <div className="ml-auto">
+            {data.session ? (
+              <form action="/auth/signout" method="post">
+                <button className="text-sm">Sign out</button>
+              </form>
+            ) : (
+              <a href="/login" className="text-sm">Log in</a>
+            )}
+          </div>
+        </nav>
+        <main className="p-6">{children}</main>
+      </body>
+    </html>
+  );
+}

--- a/web/app/ledger/page.tsx
+++ b/web/app/ledger/page.tsx
@@ -1,0 +1,34 @@
+'use client';
+import { useEffect, useState } from 'react';
+import AutoSizer from 'react-virtualized-auto-sizer';
+import { FixedSizeList as List } from 'react-window';
+
+export default function LedgerTable() {
+  const [rows, setRows] = useState<any[]>([]);
+  useEffect(() => {
+    fetch('/api/events?org=1&limit=1000').then(r => r.json()).then(setRows);
+  }, []);
+
+  return (
+    <div className="h-[75vh] border rounded">
+      <AutoSizer>
+        {({ height, width }) => (
+          <List height={height} itemCount={rows.length} itemSize={40} width={width}>
+            {({ index, style }) => {
+              const r = rows[index];
+              return (
+                <div style={style} className="flex px-2 text-sm border-b">
+                  <div className="w-4/12">{r.sku}</div>
+                  <div className="w-2/12">{r.region}</div>
+                  <div className="w-2/12">{r.kg.toFixed(1)} kg</div>
+                  <div className="w-2/12">{r.kwh.toFixed(0)} kWh</div>
+                  <div className="w-2/12">{new Date(r.ts).toLocaleDateString()}</div>
+                </div>
+              );
+            }}
+          </List>
+        )}
+      </AutoSizer>
+    </div>
+  );
+}

--- a/web/app/login/page.tsx
+++ b/web/app/login/page.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useState } from 'react';
+import { createBrowserClient } from '@supabase/auth-helpers-nextjs';
+
+export default function Login() {
+  const supabase = createBrowserClient();
+  const [email, setEmail] = useState('');
+  const [sent, setSent] = useState(false);
+
+  const signIn = async () => {
+    await supabase.auth.signInWithOtp({ email, options: { emailRedirectTo: '/' } });
+    setSent(true);
+  };
+
+  return sent ? (
+    <p>Check your inbox…</p>
+  ) : (
+    <div className="max-w-sm mx-auto">
+      <h1 className="text-2xl font-medium mb-4">Log in</h1>
+      <input
+        className="border p-2 w-full mb-4"
+        placeholder="you@example.com"
+        onChange={(e) => setEmail(e.target.value)}
+      />
+      <button onClick={signIn} className="w-full bg-emerald-600 text-white p-2 rounded">
+        Send magic link
+      </button>
+    </div>
+  );
+}

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -1,0 +1,11 @@
+import dynamic from 'next/dynamic';
+const Kpi = dynamic(() => import('./_components/kpi-card'), { ssr: false });
+
+export default function Dashboard() {
+  return (
+    <section className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+      <Kpi />
+      {/* Future: Δ Cost, Green Commits */}
+    </section>
+  );
+}

--- a/web/next-env.d.ts
+++ b/web/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: { appDir: true },
+};
+
+module.exports = nextConfig;

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "verdledger-web",
+  "private": true,
+  "version": "0.1.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@supabase/auth-helpers-nextjs": "^0.8.0",
+    "@supabase/supabase-js": "^2.0.0",
+    "swr": "^2.3.0",
+    "zustand": "^4.0.0",
+    "@tanstack/react-table": "^8.0.0",
+    "react-virtualized-auto-sizer": "^1.0.0",
+    "react-window": "^1.8.7"
+  },
+  "devDependencies": {
+    "eslint-config-next": "14.0.0",
+    "@playwright/test": "^1.42.1"
+  }
+}

--- a/web/tests/dashboard.spec.ts
+++ b/web/tests/dashboard.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('kpi loads', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  const kpi = page.locator('text=/CO₂ Avoided/');
+  await expect(kpi).toContainText('kg');
+});

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/web/utils/supabase-client.ts
+++ b/web/utils/supabase-client.ts
@@ -1,0 +1,5 @@
+import { createRouteHandlerClient } from '@supabase/auth-helpers-nextjs';
+import { cookies } from 'next/headers';
+
+export const createClient = () =>
+  createRouteHandlerClient({ cookies });


### PR DESCRIPTION
## Summary
- set up new `web` workspace for Next.js 14 dashboard
- create Supabase client helpers and auth route
- add KPI card, ledger table and login page
- provide API route proxies
- configure Playwright tests and CI step
- include `test:e2e` script

## Testing
- `pnpm exec playwright test` *(fails: cannot reach registry)*
- `pnpm test` *(fails: cannot reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_686d9dd2a458833098867264d5b87db9