### PR TITLE
Add optimizer plugin skeleton

### DIFF
--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -13,6 +13,7 @@ var root = &cobra.Command{
 
 func main() {
 	root.AddCommand(cmdScan())
+	root.AddCommand(cmdOptimize())
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/cli/optimize.go
+++ b/cmd/cli/optimize.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func cmdOptimize() *cobra.Command {
+	var (
+		runtime uint
+		apply   bool
+		apiURL  string
+		token   string
+	)
+	c := &cobra.Command{
+		Use:   "optimize",
+		Short: "Suggest greener region for workload",
+		RunE: func(_ *cobra.Command, args []string) error {
+			cur := os.Getenv("AWS_REGION")
+			cand := []string{"us-east-1", "us-west-2", "eu-west-1"}
+			body, _ := json.Marshal(map[string]any{
+				"cloud":             "aws",
+				"current_region":    cur,
+				"candidate_regions": cand,
+				"runtime_hours":     runtime,
+			})
+			req, _ := http.NewRequest("POST", apiURL+"/v1/optimizer/suggest", bytes.NewReader(body))
+			req.Header.Set("Content-Type", "application/json")
+			if token != "" {
+				req.Header.Set("Authorization", "Bearer "+token)
+			}
+			res, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return err
+			}
+			defer res.Body.Close()
+			var out struct {
+				BestRegion string  `json:"best_region"`
+				StartIso   string  `json:"start_iso"`
+				KgSaved    float64 `json:"kg_saved"`
+			}
+			if err := json.NewDecoder(res.Body).Decode(&out); err != nil {
+				return err
+			}
+			fmt.Printf("Best region %s saves %.1f kg CO2\n", out.BestRegion, out.KgSaved)
+			if apply {
+				fmt.Printf("aws ec2 stop-instances --instance-ids i-123 && aws ec2 start-instances --region %s ...\n", out.BestRegion)
+			}
+			return nil
+		},
+	}
+	c.Flags().UintVar(&runtime, "runtime", 1, "Runtime hours")
+	c.Flags().BoolVar(&apply, "apply", false, "Show move command")
+	c.Flags().StringVar(&apiURL, "api", "http://localhost:8080", "API base URL")
+	c.Flags().StringVar(&token, "token", os.Getenv("VERDLEDGER_TOKEN"), "Bearer token")
+	return c
+}

--- a/internal/api/router.go
+++ b/internal/api/router.go
@@ -24,6 +24,7 @@ func Router() http.Handler {
 	r.Post("/v1/events", postEvent)
 	r.Get("/v1/summary", getSummary)
 	r.Post("/webhook/stripe", stripeWebhook)
+	r.With(middleware.RequireFlag("realtime_grid_optimizer")).Post("/v1/optimizer/suggest", optimizerSuggest)
 
 	return r
 }
@@ -182,4 +183,10 @@ func getMe(w http.ResponseWriter, r *http.Request) {
 		out.Orgs = append(out.Orgs, o)
 	}
 	_ = json.NewEncoder(w).Encode(out)
+}
+
+// -------- /v1/optimizer/suggest -------------------------------
+func optimizerSuggest(w http.ResponseWriter, r *http.Request) {
+	// proxy request to optimizer plugin (stub)
+	http.Error(w, "optimizer unavailable", http.StatusServiceUnavailable)
 }

--- a/internal/ledger/queries/optimizer.sql
+++ b/internal/ledger/queries/optimizer.sql
@@ -1,0 +1,9 @@
+-- name: InsertOptimizerJob :one
+INSERT INTO public.optimizer_job (org_id, project_id, cloud, resources)
+VALUES ($1,$2,$3,$4)
+RETURNING *;
+
+-- name: InsertOptimizerRun :one
+INSERT INTO public.optimizer_run (job_id, scheduled_ts, from_region, to_region, kg_delta, usd_delta, recommended)
+VALUES ($1,$2,$3,$4,$5,$6,$7)
+RETURNING *;

--- a/migrations/202508180900_optimizer.sql
+++ b/migrations/202508180900_optimizer.sql
@@ -1,0 +1,36 @@
+-- +goose Up
+create table public.optimizer_job (
+  id           bigserial primary key,
+  org_id       bigint references public.org(id) on delete cascade,
+  project_id   bigint references public.project(id),
+  cloud        text,
+  resources    jsonb,
+  created_at   timestamptz default now(),
+  status       text default 'pending'
+);
+
+create table public.optimizer_run (
+  id           bigserial primary key,
+  job_id       bigint references public.optimizer_job(id) on delete cascade,
+  scheduled_ts timestamptz,
+  from_region  text,
+  to_region    text,
+  kg_delta     numeric,
+  usd_delta    numeric,
+  recommended  boolean,
+  created_at   timestamptz default now()
+);
+
+alter table public.optimizer_job  enable row level security;
+alter table public.optimizer_run  enable row level security;
+
+create policy "Org members" on public.optimizer_job
+  for select using (exists (select 1 from public.current_user_orgs c where c.org_id = org_id));
+
+create policy "Org members" on public.optimizer_run
+  for select using (exists (select 1 from public.current_user_orgs c where c.org_id =
+    (select org_id from public.optimizer_job j where j.id = job_id)));
+
+-- +goose Down
+drop table public.optimizer_run;
+drop table public.optimizer_job;

--- a/plugins/optimizer/api.proto
+++ b/plugins/optimizer/api.proto
@@ -1,0 +1,20 @@
+syntax = "proto3";
+package optimizer.v1;
+
+service Scheduler {
+  rpc Suggest (SuggestRequest) returns (SuggestReply);
+}
+
+message SuggestRequest {
+  string cloud = 1;
+  string current_region = 2;
+  repeated string candidate_regions = 3;
+  uint32 runtime_hours = 4;
+}
+
+message SuggestReply {
+  string best_region = 1;
+  string start_iso = 2;
+  double kg_saved = 3;
+  double kg_baseline = 4;
+}

--- a/plugins/optimizer/go.mod
+++ b/plugins/optimizer/go.mod
@@ -1,0 +1,3 @@
+module github.com/verdledger/optimizer
+
+go 1.23

--- a/plugins/optimizer/http.go
+++ b/plugins/optimizer/http.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gorilla/mux"
+	opt "github.com/verdledger/optimizer/optimizer/v1"
+)
+
+func routes(s opt.SchedulerServer) http.Handler {
+	r := mux.NewRouter()
+	r.HandleFunc("/v1/optimizer/suggest", func(w http.ResponseWriter, r *http.Request) {
+		var req opt.SuggestRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		res, err := s.Suggest(r.Context(), &req)
+		if err != nil {
+			http.Error(w, err.Error(), 500)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(res)
+	}).Methods("POST")
+	return r
+}

--- a/plugins/optimizer/main.go
+++ b/plugins/optimizer/main.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"log"
+	"net"
+	"net/http"
+)
+
+func main() {
+	srv := &server{}
+	go func() {
+		log.Println(http.ListenAndServe(":8080", routes(srv)))
+	}()
+	lis, err := net.Listen("tcp", ":9090")
+	if err != nil {
+		log.Fatal(err)
+	}
+	// gRPC server stub omitted
+	select {}
+}

--- a/plugins/optimizer/optimizer/v1/api.pb.go
+++ b/plugins/optimizer/optimizer/v1/api.pb.go
@@ -1,0 +1,30 @@
+package optimizer
+
+import "context"
+
+// Placeholder definitions for proto messages and service interface
+
+type SuggestRequest struct {
+	Cloud            string
+	CurrentRegion    string
+	CandidateRegions []string
+	RuntimeHours     uint32
+}
+
+type SuggestReply struct {
+	BestRegion string
+	StartIso   string
+	KgSaved    float64
+	KgBaseline float64
+}
+
+type UnimplementedSchedulerServer struct{}
+
+func (UnimplementedSchedulerServer) Suggest(ctx context.Context, req *SuggestRequest) (*SuggestReply, error) {
+	return nil, nil
+}
+
+// SchedulerServer defines the server API for Scheduler service.
+type SchedulerServer interface {
+	Suggest(context.Context, *SuggestRequest) (*SuggestReply, error)
+}

--- a/plugins/optimizer/server.go
+++ b/plugins/optimizer/server.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"time"
+
+	opt "github.com/verdledger/optimizer/optimizer/v1"
+)
+
+type server struct {
+	opt.UnimplementedSchedulerServer
+}
+
+const wattsPerVcpu = 15.0
+
+func (s *server) Suggest(ctx context.Context, req *opt.SuggestRequest) (*opt.SuggestReply, error) {
+	best := req.CurrentRegion
+	bestCI := 999.0
+	for _, region := range append([]string{req.CurrentRegion}, req.CandidateRegions...) {
+		ci, err := fetchCI(region)
+		if err != nil {
+			continue
+		}
+		if ci < bestCI {
+			bestCI = ci
+			best = region
+		}
+	}
+	kgBaseline := float64(req.RuntimeHours) * wattsPerVcpu * 1e-3 * bestCI
+	kgSaved := 0.0
+	if best != req.CurrentRegion {
+		curCI, _ := fetchCI(req.CurrentRegion)
+		kgCurrent := float64(req.RuntimeHours) * wattsPerVcpu * 1e-3 * curCI
+		kgSaved = kgCurrent - kgBaseline
+	}
+	return &opt.SuggestReply{
+		BestRegion: best,
+		StartIso:   time.Now().UTC().Format(time.RFC3339),
+		KgSaved:    kgSaved,
+		KgBaseline: kgBaseline,
+	}, nil
+}
+
+func fetchCI(zone string) (float64, error) {
+	url := fmt.Sprintf("https://api.electricitymap.org/v3/carbon-intensity/latest?zone=%s", zone)
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("auth-token", getenv("ELECTRICITYMAPS_TOKEN"))
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer res.Body.Close()
+	var body struct {
+		CarbonIntensity float64 `json:"carbonIntensity"`
+	}
+	_ = json.NewDecoder(res.Body).Decode(&body)
+	return body.CarbonIntensity, nil
+}
+
+func getenv(k string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return ""
+}
+
+func main() {}

--- a/web/app/api/optimizer/latest/route.ts
+++ b/web/app/api/optimizer/latest/route.ts
@@ -1,0 +1,7 @@
+import { NextRequest } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const url = `${process.env.NEXT_PUBLIC_API_URL}/v1/optimizer/suggest`;
+  const res = await fetch(url, { method: "POST", body: "{}" });
+  return new Response(await res.text(), { status: res.status });
+}

--- a/web/app/optimizer/page.tsx
+++ b/web/app/optimizer/page.tsx
@@ -1,0 +1,22 @@
+"use client";
+import useSWR from "swr";
+
+const fetcher = (u: string) => fetch(u).then((r) => r.json());
+
+export default function Optimizer() {
+  const { data } = useSWR("/api/optimizer/latest", fetcher);
+  if (!data) return <>Loading…</>;
+
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-semibold">Realtime Grid Optimizer</h1>
+      <p>
+        Best slot: <strong>{data.best_region}</strong> at{" "}
+        {new Date(data.start_iso).toLocaleString()}
+      </p>
+      <p>
+        Estimated saving: <strong>{data.kg_saved.toFixed(1)} kg CO₂</strong>
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add database tables for optimizer jobs and runs
- add placeholder proto API and service
- expose `/v1/optimizer/suggest` route under feature flag
- add CLI `optimize` command
- add basic optimizer page and API route

## Testing
- `go test ./...` *(fails: proxy blocked)*
- `pnpm test` *(fails: proxy blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686da97e6f408330b62b0014bb935e74